### PR TITLE
Allow users to login with stuypulse.com emails.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "haml"
 gem "haml-rails"
 
 gem 'devise'
+gem 'omniauth-google-oauth2'
 gem 'pundit'
 gem 'paper_trail'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     erubi (1.7.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.12.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -102,6 +104,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hashie (3.5.7)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -119,6 +122,7 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (2.1.0)
+    jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -145,10 +149,28 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    multi_xml (0.6.0)
+    multipart-post (2.0.0)
     nested_form (0.3.2)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-google-oauth2 (0.5.3)
+      jwt (>= 1.5)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.5)
+    omniauth-oauth2 (1.5.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.2)
     orm_adapter (0.5.0)
     paper_trail (9.2.0)
       activerecord (>= 4.2, < 5.3)
@@ -293,6 +315,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  omniauth-google-oauth2
   paper_trail
   phony_rails
   postmark-rails (~> 0.15.0)
@@ -312,4 +335,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,13 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def google_oauth2
+      @user = User.from_omniauth(request.env['omniauth.auth'])
+
+      if @user.persisted?
+        flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Google'
+        sign_in_and_redirect @user, event: :authentication
+      else
+        session['devise.google_data'] = request.env['omniauth.auth'].except(:extra) # Removing extra as it can overflow some session stores
+        redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
+      end
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,7 +7,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         sign_in_and_redirect @user, event: :authentication
       else
         session['devise.google_data'] = request.env['omniauth.auth'].except(:extra) # Removing extra as it can overflow some session stores
-        redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
+        redirect_to new_user_session_url, alert: @user.errors.full_messages.join("\n")
       end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,22 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable,
          :rememberable, :trackable, :validatable,
          :timeoutable
+  devise :omniauthable, omniauth_providers: [:google_oauth2]
 
   has_paper_trail
 
   has_one :student
+
+  def self.from_omniauth(access_token)
+    data = access_token.info
+    user = User.where(email: data['email']).first
+
+    unless user
+      user = User.create(email: data['email'],
+          password: Devise.friendly_token[0,20]
+         )
+    end
+
+    user
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  EMAIL_DOMAIN_WHITELIST = %w(stuypulse.com)
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :recoverable,
@@ -9,6 +11,17 @@ class User < ApplicationRecord
   has_paper_trail
 
   has_one :student
+
+  validate :email_domain_is_in_whitelist
+
+  def email_domain_is_in_whitelist
+    EMAIL_DOMAIN_WHITELIST.each do |domain|
+      return if email.ends_with? "@#{domain}"
+    end
+
+    errors.add(:email, "domain is not allowed. Allowed domains:
+                         #{EMAIL_DOMAIN_WHITELIST.join(", ")}")
+  end
 
   def self.from_omniauth(access_token)
     data = access_token.info

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,6 +251,9 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :google_oauth2,
+                  Rails.application.secrets.google_client_id,
+                  Rails.application.secrets.google_client_secret, {}
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :media_consents
   resources :team_dues
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   resources :parents
   resources :teams

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,16 +20,17 @@
 development:
   secret_key_base: 81a045e24dbde5605935f9cbcc441082af469275c53a84e2aa9a412789c877fcc8b57f3ecdfbc96910d0ab355260ea339582d8b75c9edac39d79c6f44fdf0287
   postmark_api_token: <%= ENV['POSTMARK_API_TOKEN'] %>
+  google_client_id: <%= ENV['GOOGLE_CLIENT_ID'] %>
+  google_client_secret: <%= ENV['GOOGLE_CLIENT_SECRET'] %>
 
 test:
   secret_key_base: 8182a5da85e3cd1070cff08ababb6a624d45d09c763a5640e40f5842e8d79f6a62dee193a2ddf6c4c593b04d5c2200dd6627e9c76b8cf0d989f335c8c6b36ebd
   postmark_api_token: <%= ENV['POSTMARK_API_TOKEN'] %>
-
-# Do not keep production secrets in the unencrypted secrets file.
-# Instead, either read values from the environment.
-# Or, use `bin/rails secrets:setup` to configure encrypted secrets
-# and move the `production:` environment over there.
+  google_client_id: <%= ENV['GOOGLE_CLIENT_ID'] %>
+  google_client_secret: <%= ENV['GOOGLE_CLIENT_SECRET'] %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   postmark_api_token: <%= ENV['POSTMARK_API_TOKEN'] %>
+  google_client_id: <%= ENV['GOOGLE_CLIENT_ID'] %>
+  google_client_secret: <%= ENV['GOOGLE_CLIENT_SECRET'] %>

--- a/db/migrate/20180720215104_add_omniauth_to_users.rb
+++ b/db/migrate/20180720215104_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223153443) do
+ActiveRecord::Schema.define(version: 20180720215104) do
 
   create_table "affiliations", force: :cascade do |t|
     t.string "name", null: false
@@ -232,6 +232,8 @@ ActiveRecord::Schema.define(version: 20180223153443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_admin", default: false, null: false
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,18 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = User.new(email: "test",
+                     password: "test_password")
+  end
+
+  test "stuypulse.com email will pass validation" do
+    @user.email = "bryan.lai@stuypulse.com"
+    assert @user.valid?
+  end
+
+  test "non-stuypulse.com email will not pass validation" do
+    @user.email = "justin@kim@ironpulse.com"
+    refute @user.valid?
+  end
 end


### PR DESCRIPTION
Use OmniAuth to be able to log in through email and restrict login to be accessible by only stuypulse.com emails.