### PR TITLE
Update rubyzip and set constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "haml-rails"
 gem 'devise'
 gem 'omniauth-google-oauth2'
 gem 'pundit'
-gem 'paper_trail'
+gem 'paper_trail', '~> 9.2.0'
 
 gem 'rails_admin', '~> 1.2'
 gem 'rails_admin_pundit', :github => "sudosu/rails_admin_pundit"
@@ -52,6 +52,7 @@ gem 'postmark-rails', '~> 0.15.0'
 gem 'auto_strip_attributes', "~> 2.2"
 gem 'phony_rails'
 
+gem 'rubyzip', '~> 1.2.2'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -316,7 +316,7 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   omniauth-google-oauth2
-  paper_trail
+  paper_trail (~> 9.2.0)
   phony_rails
   postmark-rails (~> 0.15.0)
   puma (~> 3.7)
@@ -324,6 +324,7 @@ DEPENDENCIES
   rails (~> 5.1.2)
   rails_admin (~> 1.2)
   rails_admin_pundit!
+  rubyzip (~> 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver
   spring


### PR DESCRIPTION
Set constraints for both paper_trail 9.2.0 and rubyzip 1.2.2 for security issues.